### PR TITLE
Replace lodash with underscore

### DIFF
--- a/helpers/getJson.ts
+++ b/helpers/getJson.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash'
+import * as _ from 'underscore'
 const getJson = (collection: any): string => {
 	const arr: object[] = []
 	collection.each((s: any) => {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   ],
   "dependencies": {
     "active-resource": "^1.0.0-beta.7",
-    "axios": "^0.19.0",
-    "lodash": "^4.17.20"
+    "axios": "^0.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import _ from 'lodash'
+import _ from 'underscore'
 import { getTokenBlueBrand } from '../../helpers/getToken'
 import { initCLayer, Order } from '../../src'
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import _ from 'lodash'
+import _ from 'underscore'
 import { Sku } from '../src'
 import { getTokenBlueBrandWeb } from '../helpers/getToken'
 

--- a/src/resources/library.ts
+++ b/src/resources/library.ts
@@ -6,7 +6,7 @@ import {
 } from 'active-resource'
 import Library, { GeneralObject } from '#typings/Library'
 import { InitConfig } from './Initialize'
-import _ from 'lodash'
+import _ from 'underscore'
 import BaseClass from '#utils/BaseClass'
 import { cleanUrl, parserParams } from '#utils/helpers'
 import axios from 'axios'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import _ from 'underscore'
 
 export const cleanUrl = (url: string) => {
   const lastSlash = url.lastIndexOf('/') + 1


### PR DESCRIPTION
Hello @acasazza , while optimizing our application bundle we saw that the SDK includes the whole lodash build, while active-resource already uses underscore.js under the hood.
Although lodash is newer and generally better, if the SDK uses underscore we can avoid loading another heavy dependency and save ~100kb.

We've forked the project and replaced lodash occurencies, and were able to save 80% of lodash size ( the other 20% is used by other dependencies in our project ). Some screenshots for reference:

With lodash:
<img width="513" alt="Screenshot 2021-03-02 at 23 32 17" src="https://user-images.githubusercontent.com/28622728/109865251-238dc700-7c64-11eb-82d1-c75240ea9ddc.png">

With underscore:
<img width="430" alt="Screenshot 2021-03-02 at 23 32 33" src="https://user-images.githubusercontent.com/28622728/109865309-30121f80-7c64-11eb-97a0-f761790ad895.png">

I'm not sure how to properly run tests, as they give 401 responses.
Also, I did not update the package-lock.json as i dont have npm 7 installed.

Hopefully this is a good enough optimization worth considering.
Thanks!